### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -448,7 +448,7 @@ We appreciate all contributions. If you are planning to contribute back bug-fixe
 If you plan to contribute new features, utility functions, or extensions to the core, please first open an issue and discuss the feature with us.
 Sending a PR without discussion might end up resulting in a rejected PR because we might be taking the core in a different direction than you might be aware of.
 
-To learn more about making a contribution to Pytorch, please see our [Contribution page](CONTRIBUTING.md). For more information about PyTorch releases, see [Release page](RELEASE.md).
+To learn more about making a contribution to PyTorch, please see our [Contribution page](CONTRIBUTING.md). For more information about PyTorch releases, see [Release page](RELEASE.md).
 
 ## The Team
 


### PR DESCRIPTION
In the documentation, there is a minor grammatical error where "Pytorch" is written with a lowercase "t" instead of "PyTorch" with a capital "T." It is essential to maintain consistency in the naming of the software throughout the documentation to ensure clarity and professionalism.

Fixes #ISSUE_NUMBER
